### PR TITLE
Add github tool to chat handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,14 @@ Wait for new pods to show `Running` and old pods to terminate.
 - For new features, use `playwright-test-planner` to explore and generate plans
 - Use `playwright-test-generator` to create tests from plans
 
+**GitHub mocking:**
+
+Test environment uses `USE_MOCK_GITHUB=true` to avoid hitting the real GitHub API. When adding new GitHub API functions:
+
+1. Add mock implementation to `backend/src/mainloop/services/github_mock.py`
+2. Add function name to `funcs_to_mock` list in `backend/src/mainloop/api.py`
+3. Mock should return realistic test data, not empty responses
+
 ## Key Patterns
 
 - **Pydantic models** in `models/` shared between frontend types and backend

--- a/backend/src/mainloop/api.py
+++ b/backend/src/mainloop/api.py
@@ -94,6 +94,10 @@ def _apply_mock_github():
         "acknowledge_comments",
         "is_pr_merged",
         "is_pr_approved",
+        # Chat tool functions
+        "get_repo_metadata",
+        "list_open_issues",
+        "list_open_prs",
     ]
     for name in funcs_to_mock:
         if hasattr(github_mock, name):

--- a/backend/src/mainloop/services/github_mock.py
+++ b/backend/src/mainloop/services/github_mock.py
@@ -144,9 +144,9 @@ from mainloop.services.github_pr import (  # noqa: E402
     CreatedIssue,
     IssueSummary,
     PRComment,
+    ProjectPRSummary,
     PRReview,
     PRStatus,
-    ProjectPRSummary,
     RepoMetadata,
 )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,9 +65,21 @@ Mainloop uses a coordinator/worker pattern where a fast main thread agent delega
 1. User sends message via frontend
 2. Backend receives request (authenticated via Cloudflare Access)
 3. Main thread (Haiku) analyzes intent
-4. If task needed: spawn worker (Opus) with task details
-5. Worker executes autonomously, may ask questions via queue
-6. Results flow back to main thread → user
+4. For info requests: use `github` tool directly (list issues, get repo info)
+5. If coding task needed: spawn worker (Opus) with task details
+6. Worker executes autonomously, may ask questions via queue
+7. Results flow back to main thread → user
+
+## Chat Tools
+
+The main thread agent has access to these tools:
+
+| Tool         | Purpose                       | Actions                                                                             |
+| ------------ | ----------------------------- | ----------------------------------------------------------------------------------- |
+| `github`     | Read repo info, manage issues | list_issues, list_prs, get_repo, get_issue, create_issue, update_issue, add_comment |
+| `spawn_task` | Spawn autonomous worker       | Creates worker with full codebase access                                            |
+
+The agent uses `github` for information requests and `spawn_task` for coding work.
 
 ## Model Configuration
 

--- a/frontend/specs/README.md
+++ b/frontend/specs/README.md
@@ -42,3 +42,4 @@ Brief description of what this feature does.
 - [inbox-management.md](./inbox-management.md) - Inbox panel and queue items
 - [task-interactions.md](./task-interactions.md) - Question answering and plan review
 - [mobile-navigation.md](./mobile-navigation.md) - Mobile tab bar navigation
+- [github-tool.md](./github-tool.md) - Chat agent GitHub integration

--- a/frontend/specs/github-tool.md
+++ b/frontend/specs/github-tool.md
@@ -1,0 +1,34 @@
+# GitHub Tool Test Plan
+
+## Application Overview
+
+The chat handler provides a `github` tool that allows the main thread agent to read repository information and manage GitHub issues directly, without spawning a worker task. This was added because users asking about GitHub issues/PRs were told "I don't have access to GitHub" when the chat agent only had the `spawn_task` tool.
+
+**Tool Actions:**
+
+- `list_issues` - List open issues for a repository
+- `list_prs` - List open PRs for a repository
+- `get_repo` - Get repository metadata
+- `get_issue` - Get details of a specific issue
+- `create_issue` - Create a new issue
+- `update_issue` - Update an existing issue
+- `add_comment` - Add a comment to an issue
+
+## Test Scenarios
+
+### 1. Info Requests Use GitHub Tool
+
+**Seed:** tests/seed.spec.ts
+
+#### 1.1 List Issues Without Spawn Offer
+
+**Steps:**
+
+1. Send message: "List open issues on https://github.com/oldsj/mainloop"
+2. Wait for response
+
+**Expected:**
+
+- Response contains issue information
+- Response does NOT say "don't have access" or "cannot access"
+- Response does NOT offer to spawn a task or worker

--- a/frontend/tests/e2e/github-tool.spec.ts
+++ b/frontend/tests/e2e/github-tool.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, chat } from '../fixtures';
+
+/**
+ * GitHub tool E2E test - verifies the chat agent can access GitHub.
+ *
+ * Uses real Claude API with mocked GitHub API (USE_MOCK_GITHUB=true).
+ */
+
+test.describe('GitHub Tool', () => {
+  test.setTimeout(90000);
+
+  test('uses github tool for info requests', async ({ appPage }) => {
+    const response = await chat(appPage, 'List open issues on https://github.com/oldsj/mainloop');
+
+    // Should have access and return issue info
+    expect(response.toLowerCase()).not.toContain("don't have access");
+    expect(response.toLowerCase()).not.toContain('cannot access');
+    expect(response.toLowerCase()).toContain('issue');
+
+    // Should NOT offer to spawn a task for info requests
+    expect(response.toLowerCase()).not.toContain('spawn a task');
+    expect(response.toLowerCase()).not.toContain('spawn a worker');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `github` tool to chat handler with 7 actions (list_issues, list_prs, get_repo, get_issue, create_issue, update_issue, add_comment)
- Chat agent can now answer GitHub questions directly instead of saying "I don't have access"
- Add mock implementations for test environment (USE_MOCK_GITHUB=true)
- Add E2E test and spec documentation

Closes #27

## Test plan

- [x] Run `make test-run` - all 15 tests pass
- [x] Verify mock returns issue data in test environment
- [x] Verify real GitHub API works in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)